### PR TITLE
Feat/domain

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,0 +1,18 @@
+#https://www.coderabbit.ai/blog/how-to-integrate-ai-code-review-into-your-devops-pipeline 을 참고하여 설정을 추가할 수 있습니다.
+
+# yaml-language-server: $schema=https://coderabbit.ai/integrations/schema.v2.json
+language: ko-KR
+
+reviews:
+  profile: "chill"
+  request_changes_workflow: false
+  high_level_summary: true
+  changed_files_summary: false
+  poem: false
+  review_status: true
+  review_details: false
+  auto_review:
+    enabled: true
+    drafts: true
+chat:
+  auto_reply: true

--- a/src/main/java/org/ticketing/seat/SeatServiceApplication.java
+++ b/src/main/java/org/ticketing/seat/SeatServiceApplication.java
@@ -1,4 +1,4 @@
-package com.ticketing.seat;
+package org.ticketing.seat;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;

--- a/src/main/java/org/ticketing/seat/application/dto/command/CreateSeatGradeCommand.java
+++ b/src/main/java/org/ticketing/seat/application/dto/command/CreateSeatGradeCommand.java
@@ -1,0 +1,9 @@
+package org.ticketing.seat.application.dto.command;
+
+import java.util.UUID;
+
+public record CreateSeatGradeCommand(
+        UUID stadiumId,
+        String gradeName
+) {
+}

--- a/src/main/java/org/ticketing/seat/application/dto/command/CreateSeatsBulkCommand.java
+++ b/src/main/java/org/ticketing/seat/application/dto/command/CreateSeatsBulkCommand.java
@@ -1,0 +1,13 @@
+package org.ticketing.seat.application.dto.command;
+
+import java.util.List;
+import java.util.UUID;
+
+public record CreateSeatsBulkCommand(
+        UUID stadiumId,
+        UUID seatGradeId,
+        List<String> columns,
+        Integer startNumber,
+        Integer endNumber
+) {
+}

--- a/src/main/java/org/ticketing/seat/application/dto/command/CreateSeatsCommand.java
+++ b/src/main/java/org/ticketing/seat/application/dto/command/CreateSeatsCommand.java
@@ -1,0 +1,16 @@
+package org.ticketing.seat.application.dto.command;
+
+import java.util.List;
+import java.util.UUID;
+
+public record CreateSeatsCommand(
+        UUID stadiumId,
+        List<SeatItem> seats
+) {
+
+    public record SeatItem(
+            String column,
+            Integer seatNumber,
+            UUID seatGradeId
+    ) {}
+}

--- a/src/main/java/org/ticketing/seat/application/dto/command/DeleteSeatCommand.java
+++ b/src/main/java/org/ticketing/seat/application/dto/command/DeleteSeatCommand.java
@@ -1,0 +1,9 @@
+package org.ticketing.seat.application.dto.command;
+
+import java.util.UUID;
+
+public record DeleteSeatCommand(
+        UUID seatId,
+        String deletedBy
+) {
+}

--- a/src/main/java/org/ticketing/seat/application/dto/command/DeleteSeatGradeCommand.java
+++ b/src/main/java/org/ticketing/seat/application/dto/command/DeleteSeatGradeCommand.java
@@ -1,0 +1,9 @@
+package org.ticketing.seat.application.dto.command;
+
+import java.util.UUID;
+
+public record DeleteSeatGradeCommand(
+        UUID seatGradeId,
+        String deletedBy
+) {
+}

--- a/src/main/java/org/ticketing/seat/application/dto/command/UpdateSeatGradeCommand.java
+++ b/src/main/java/org/ticketing/seat/application/dto/command/UpdateSeatGradeCommand.java
@@ -1,0 +1,9 @@
+package org.ticketing.seat.application.dto.command;
+
+import java.util.UUID;
+
+public record UpdateSeatGradeCommand(
+        UUID seatId,
+        UUID seatGradeId
+) {
+}

--- a/src/main/java/org/ticketing/seat/application/dto/command/UpdateSeatGradeNameCommand.java
+++ b/src/main/java/org/ticketing/seat/application/dto/command/UpdateSeatGradeNameCommand.java
@@ -1,0 +1,9 @@
+package org.ticketing.seat.application.dto.command;
+
+import java.util.UUID;
+
+public record UpdateSeatGradeNameCommand(
+        UUID seatGradeId,
+        String gradeName
+) {
+}

--- a/src/main/java/org/ticketing/seat/application/dto/query/GetSeatsQuery.java
+++ b/src/main/java/org/ticketing/seat/application/dto/query/GetSeatsQuery.java
@@ -1,0 +1,13 @@
+package org.ticketing.seat.application.dto.query;
+
+import org.springframework.data.domain.Pageable;
+
+import java.util.UUID;
+
+public record GetSeatsQuery(
+        UUID stadiumId,
+        UUID seatGradeId,
+        String column,
+        Pageable pageable
+) {
+}

--- a/src/main/java/org/ticketing/seat/application/dto/result/GetSeatGradesResult.java
+++ b/src/main/java/org/ticketing/seat/application/dto/result/GetSeatGradesResult.java
@@ -1,0 +1,8 @@
+package org.ticketing.seat.application.dto.result;
+
+import java.util.List;
+
+public record GetSeatGradesResult(
+        List<SeatGradeResult> seatGrades
+) {
+}

--- a/src/main/java/org/ticketing/seat/application/dto/result/GetSeatsResult.java
+++ b/src/main/java/org/ticketing/seat/application/dto/result/GetSeatsResult.java
@@ -1,0 +1,12 @@
+package org.ticketing.seat.application.dto.result;
+
+import java.util.List;
+
+public record GetSeatsResult(
+        List<SeatResult> seats,
+        int page,
+        int size,
+        long totalElements,
+        int totalPages
+) {
+}

--- a/src/main/java/org/ticketing/seat/application/dto/result/SeatGradeResult.java
+++ b/src/main/java/org/ticketing/seat/application/dto/result/SeatGradeResult.java
@@ -1,0 +1,9 @@
+package org.ticketing.seat.application.dto.result;
+
+import java.util.UUID;
+
+public record SeatGradeResult(
+        UUID seatGradeId,
+        String gradeName
+) {
+}

--- a/src/main/java/org/ticketing/seat/application/dto/result/SeatResult.java
+++ b/src/main/java/org/ticketing/seat/application/dto/result/SeatResult.java
@@ -1,0 +1,13 @@
+package org.ticketing.seat.application.dto.result;
+
+import java.util.UUID;
+
+public record SeatResult(
+        UUID seatId,
+        UUID stadiumId,
+        String column,
+        Integer seatNumber,
+        UUID seatGradeId,
+        String gradeName
+) {
+}

--- a/src/main/java/org/ticketing/seat/application/service/SeatApplicationService.java
+++ b/src/main/java/org/ticketing/seat/application/service/SeatApplicationService.java
@@ -13,12 +13,10 @@ import java.util.UUID;
 
 @Service
 @RequiredArgsConstructor
-@Transactional(readOnly = true)
 public class SeatApplicationService {
 
     // TODO: repository 주입
     // private final SeatRepository seatRepository;
-    // private final SeatGradeRepository seatGradeRepository;
 
     /**
      * 좌석 생성
@@ -67,44 +65,6 @@ public class SeatApplicationService {
      */
     @Transactional
     public void deleteSeat(DeleteSeatCommand command) {
-        throw new UnsupportedOperationException("Not implemented yet");
-    }
-
-    /**
-     * 좌석 등급 생성
-     */
-    @Transactional
-    public void createSeatGrade(CreateSeatGradeCommand command) {
-        throw new UnsupportedOperationException("Not implemented yet");
-    }
-
-    /**
-     * 좌석 등급명 수정
-     */
-    @Transactional
-    public void updateSeatGradeName(UpdateSeatGradeNameCommand command) {
-        throw new UnsupportedOperationException("Not implemented yet");
-    }
-
-    /**
-     * 좌석 등급 삭제
-     */
-    @Transactional
-    public void deleteSeatGrade(DeleteSeatGradeCommand command) {
-        throw new UnsupportedOperationException("Not implemented yet");
-    }
-
-    /**
-     * 경기장 좌석 등급 목록 조회
-     */
-    public GetSeatGradesResult getSeatGrades(UUID stadiumId) {
-        throw new UnsupportedOperationException("Not implemented yet");
-    }
-
-    /**
-     * 좌석 등급 존재 여부 (internal API)
-     */
-    public boolean existsSeatGrade(UUID seatGradeId) {
         throw new UnsupportedOperationException("Not implemented yet");
     }
 }

--- a/src/main/java/org/ticketing/seat/application/service/SeatApplicationService.java
+++ b/src/main/java/org/ticketing/seat/application/service/SeatApplicationService.java
@@ -1,0 +1,110 @@
+package org.ticketing.seat.application.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.ticketing.seat.application.dto.command.*;
+import org.ticketing.seat.application.dto.query.GetSeatsQuery;
+import org.ticketing.seat.application.dto.result.*;
+import org.ticketing.seat.domain.model.entity.Seat;
+
+import java.util.List;
+import java.util.UUID;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class SeatApplicationService {
+
+    // TODO: repository 주입
+    // private final SeatRepository seatRepository;
+    // private final SeatGradeRepository seatGradeRepository;
+
+    /**
+     * 좌석 생성
+     */
+    @Transactional
+    public void createSeats(CreateSeatsCommand command) {
+        throw new UnsupportedOperationException("Not implemented yet");
+    }
+
+    /**
+     * 좌석 자동 생성
+     */
+    @Transactional
+    public void bulkCreateSeats(CreateSeatsBulkCommand command) {
+        throw new UnsupportedOperationException("Not implemented yet");
+    }
+
+    /**
+     * 좌석 목록 조회
+     */
+    public GetSeatsResult getSeats(GetSeatsQuery query) {
+        throw new UnsupportedOperationException("Not implemented yet");
+    }
+
+    public List<SeatResult> getSeatsByStadium(UUID stadiumId) {
+        throw new UnsupportedOperationException("Not implemented yet");
+    }
+
+    /**
+     * 좌석 단건 조회
+     */
+    public SeatResult getSeat(UUID seatId) {
+        throw new UnsupportedOperationException("Not implemented yet");
+    }
+
+    /**
+     * 좌석 등급 변경
+     */
+    @Transactional
+    public void updateSeatGrade(UpdateSeatGradeCommand command) {
+        throw new UnsupportedOperationException("Not implemented yet");
+    }
+
+    /**
+     * 좌석 삭제 (soft delete)
+     */
+    @Transactional
+    public void deleteSeat(DeleteSeatCommand command) {
+        throw new UnsupportedOperationException("Not implemented yet");
+    }
+
+    /**
+     * 좌석 등급 생성
+     */
+    @Transactional
+    public void createSeatGrade(CreateSeatGradeCommand command) {
+        throw new UnsupportedOperationException("Not implemented yet");
+    }
+
+    /**
+     * 좌석 등급명 수정
+     */
+    @Transactional
+    public void updateSeatGradeName(UpdateSeatGradeNameCommand command) {
+        throw new UnsupportedOperationException("Not implemented yet");
+    }
+
+    /**
+     * 좌석 등급 삭제
+     */
+    @Transactional
+    public void deleteSeatGrade(DeleteSeatGradeCommand command) {
+        throw new UnsupportedOperationException("Not implemented yet");
+    }
+
+    /**
+     * 경기장 좌석 등급 목록 조회
+     */
+    public GetSeatGradesResult getSeatGrades(UUID stadiumId) {
+        throw new UnsupportedOperationException("Not implemented yet");
+    }
+
+    /**
+     * 좌석 등급 존재 여부 (internal API)
+     */
+    public boolean existsSeatGrade(UUID seatGradeId) {
+        throw new UnsupportedOperationException("Not implemented yet");
+    }
+}

--- a/src/main/java/org/ticketing/seat/application/service/SeatGradeApplicationService.java
+++ b/src/main/java/org/ticketing/seat/application/service/SeatGradeApplicationService.java
@@ -1,0 +1,58 @@
+package org.ticketing.seat.application.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.ticketing.seat.application.dto.command.CreateSeatGradeCommand;
+import org.ticketing.seat.application.dto.command.DeleteSeatGradeCommand;
+import org.ticketing.seat.application.dto.command.UpdateSeatGradeNameCommand;
+import org.ticketing.seat.application.dto.result.GetSeatGradesResult;
+import org.ticketing.seat.domain.repository.SeatGradeRepository;
+
+import java.util.UUID;
+
+@Service
+@RequiredArgsConstructor
+public class SeatGradeApplicationService {
+
+    // TODO: repository 주입
+    // private final SeatGradeRepository seatGradeRepository;
+
+    /**
+     * 좌석 등급 생성
+     */
+    @Transactional
+    public void createSeatGrade(CreateSeatGradeCommand command) {
+        throw new UnsupportedOperationException("Not implemented yet");
+    }
+
+    /**
+     * 좌석 등급명 수정
+     */
+    @Transactional
+    public void updateSeatGradeName(UpdateSeatGradeNameCommand command) {
+        throw new UnsupportedOperationException("Not implemented yet");
+    }
+
+    /**
+     * 좌석 등급 삭제
+     */
+    @Transactional
+    public void deleteSeatGrade(DeleteSeatGradeCommand command) {
+        throw new UnsupportedOperationException("Not implemented yet");
+    }
+
+    /**
+     * 경기장 좌석 등급 목록 조회
+     */
+    public GetSeatGradesResult getSeatGrades(UUID stadiumId) {
+        throw new UnsupportedOperationException("Not implemented yet");
+    }
+
+    /**
+     * 좌석 등급 존재 여부 (internal API)
+     */
+    public boolean existsSeatGrade(UUID seatGradeId) {
+        throw new UnsupportedOperationException("Not implemented yet");
+    }
+}

--- a/src/main/java/org/ticketing/seat/domain/exception/SeatAlreadyDeletedException.java
+++ b/src/main/java/org/ticketing/seat/domain/exception/SeatAlreadyDeletedException.java
@@ -1,0 +1,12 @@
+package org.ticketing.seat.domain.exception;
+
+import org.ticketing.common.exception.BadRequestException;
+
+import java.util.UUID;
+
+public class SeatAlreadyDeletedException extends BadRequestException {
+
+    public SeatAlreadyDeletedException(UUID seatId) {
+        super("Seat already deleted: " + seatId);
+    }
+}

--- a/src/main/java/org/ticketing/seat/domain/exception/SeatGradeNotFoundException.java
+++ b/src/main/java/org/ticketing/seat/domain/exception/SeatGradeNotFoundException.java
@@ -1,0 +1,12 @@
+package org.ticketing.seat.domain.exception;
+
+import org.ticketing.common.exception.NotFoundException;
+
+import java.util.UUID;
+
+public class SeatGradeNotFoundException extends NotFoundException {
+
+    public SeatGradeNotFoundException(UUID gradeId) {
+        super("SeatGrade not found: " + gradeId);
+    }
+}

--- a/src/main/java/org/ticketing/seat/domain/exception/SeatNotFoundException.java
+++ b/src/main/java/org/ticketing/seat/domain/exception/SeatNotFoundException.java
@@ -1,0 +1,12 @@
+package org.ticketing.seat.domain.exception;
+
+import org.ticketing.common.exception.NotFoundException;
+
+import java.util.UUID;
+
+public class SeatNotFoundException extends NotFoundException {
+
+    public SeatNotFoundException(UUID seatId) {
+        super("Seat not found: " + seatId);
+    }
+}

--- a/src/main/java/org/ticketing/seat/domain/model/entity/Seat.java
+++ b/src/main/java/org/ticketing/seat/domain/model/entity/Seat.java
@@ -1,0 +1,77 @@
+package org.ticketing.seat.domain.model.entity;
+
+import jakarta.persistence.*;
+import jakarta.ws.rs.BadRequestException;
+import lombok.*;
+import org.ticketing.common.domain.BaseEntity;
+import org.ticketing.seat.domain.exception.SeatAlreadyDeletedException;
+import org.ticketing.seat.domain.model.vo.SeatLocation;
+
+import java.util.UUID;
+
+@Entity
+@Table(name = "p_seat")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Seat extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.UUID)
+    private UUID id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "seat_grade_id", nullable = false)
+    private SeatGrade seatGrade;
+
+    @Column(name = "stadium_id", nullable = false)
+    private UUID stadiumId;
+
+    @Embedded
+    private SeatLocation location;
+
+    @Builder(access = AccessLevel.PRIVATE)
+    private Seat(SeatGrade seatGrade, UUID stadiumId, SeatLocation location) {
+        validate(seatGrade, stadiumId, location);
+        this.seatGrade = seatGrade;
+        this.stadiumId = stadiumId;
+        this.location = location;
+    }
+
+    public static Seat create(SeatGrade seatGrade, UUID stadiumId, SeatLocation location) {
+        return Seat.builder()
+                .seatGrade(seatGrade)
+                .stadiumId(stadiumId)
+                .location(location)
+                .build();
+    }
+
+    public void updateSeatGrade(SeatGrade seatGrade) {
+        if (seatGrade == null) {
+            throw new BadRequestException("seatGrade is required");
+        }
+        this.seatGrade = seatGrade;
+    }
+
+    public void delete(String deletedBy) {
+        ensureNotDeleted();
+        super.delete(deletedBy);
+    }
+
+    private void validate(SeatGrade seatGrade, UUID stadiumId, SeatLocation location) {
+        if (seatGrade == null) {
+            throw new BadRequestException("seatGrade is required");
+        }
+        if (stadiumId == null) {
+            throw new BadRequestException("stadiumId is required");
+        }
+        if (location == null) {
+            throw new BadRequestException("seat location is required");
+        }
+    }
+
+    private void ensureNotDeleted() {
+        if (this.deletedAt != null) {
+            throw new SeatAlreadyDeletedException(this.id);
+        }
+    }
+}

--- a/src/main/java/org/ticketing/seat/domain/model/entity/Seat.java
+++ b/src/main/java/org/ticketing/seat/domain/model/entity/Seat.java
@@ -1,9 +1,9 @@
 package org.ticketing.seat.domain.model.entity;
 
 import jakarta.persistence.*;
-import jakarta.ws.rs.BadRequestException;
 import lombok.*;
 import org.ticketing.common.domain.BaseEntity;
+import org.ticketing.common.exception.BadRequestException;
 import org.ticketing.seat.domain.exception.SeatAlreadyDeletedException;
 import org.ticketing.seat.domain.model.vo.SeatLocation;
 

--- a/src/main/java/org/ticketing/seat/domain/model/entity/SeatGrade.java
+++ b/src/main/java/org/ticketing/seat/domain/model/entity/SeatGrade.java
@@ -1,0 +1,74 @@
+package org.ticketing.seat.domain.model.entity;
+
+import jakarta.persistence.*;
+import jakarta.ws.rs.BadRequestException;
+import lombok.*;
+import org.ticketing.common.domain.BaseEntity;
+import org.ticketing.seat.domain.exception.SeatAlreadyDeletedException;
+
+import java.util.UUID;
+
+@Entity
+@Table(name = "p_seat_grade")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class SeatGrade extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.UUID)
+    private UUID id;
+
+    @Column(name = "grade_name", nullable = false, length = 50)
+    private String gradeName;
+
+    @Column(name = "stadium_id", nullable = false)
+    private UUID stadiumId;
+
+    @Builder(access = AccessLevel.PRIVATE)
+    private SeatGrade(String gradeName, UUID stadiumId) {
+        validate(gradeName, stadiumId);
+        this.gradeName = gradeName;
+        this.stadiumId = stadiumId;
+    }
+
+    public static SeatGrade create(String gradeName, UUID stadiumId) {
+        return SeatGrade.builder()
+                .gradeName(gradeName)
+                .stadiumId(stadiumId)
+                .build();
+    }
+
+    public void updateName(String gradeName) {
+        validateName(gradeName);
+        this.gradeName = gradeName;
+    }
+
+    public void delete(String deletedBy) {
+        ensureNotDeleted();
+        super.delete(deletedBy);
+    }
+
+    private void validate(String gradeName, UUID stadiumId) {
+        validateName(gradeName);
+
+        if (stadiumId == null) {
+            throw new BadRequestException("stadiumId is required");
+        }
+    }
+
+    private void validateName(String gradeName) {
+        if (gradeName == null || gradeName.isBlank()) {
+            throw new BadRequestException("gradeName is required");
+        }
+
+        if (gradeName.length() > 50) {
+            throw new BadRequestException("gradeName max length is 50");
+        }
+    }
+
+    private void ensureNotDeleted() {
+        if (this.deletedAt != null) {
+            throw new SeatAlreadyDeletedException(this.id);
+        }
+    }
+}

--- a/src/main/java/org/ticketing/seat/domain/model/entity/SeatGrade.java
+++ b/src/main/java/org/ticketing/seat/domain/model/entity/SeatGrade.java
@@ -1,9 +1,9 @@
 package org.ticketing.seat.domain.model.entity;
 
 import jakarta.persistence.*;
-import jakarta.ws.rs.BadRequestException;
 import lombok.*;
 import org.ticketing.common.domain.BaseEntity;
+import org.ticketing.common.exception.BadRequestException;
 import org.ticketing.seat.domain.exception.SeatAlreadyDeletedException;
 
 import java.util.UUID;

--- a/src/main/java/org/ticketing/seat/domain/model/vo/SeatLocation.java
+++ b/src/main/java/org/ticketing/seat/domain/model/vo/SeatLocation.java
@@ -2,10 +2,10 @@ package org.ticketing.seat.domain.model.vo;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Embeddable;
-import jakarta.ws.rs.BadRequestException;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.ticketing.common.exception.BadRequestException;
 
 import java.util.Objects;
 
@@ -14,7 +14,7 @@ import java.util.Objects;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class SeatLocation {
 
-    @Column(name = "column", nullable = false, length = 10)
+    @Column(name = "seat_column", nullable = false, length = 10)
     private String column;
 
     @Column(name = "seat_number", nullable = false)

--- a/src/main/java/org/ticketing/seat/domain/model/vo/SeatLocation.java
+++ b/src/main/java/org/ticketing/seat/domain/model/vo/SeatLocation.java
@@ -1,0 +1,59 @@
+package org.ticketing.seat.domain.model.vo;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Embeddable;
+import jakarta.ws.rs.BadRequestException;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.Objects;
+
+@Embeddable
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class SeatLocation {
+
+    @Column(name = "column", nullable = false, length = 10)
+    private String column;
+
+    @Column(name = "seat_number", nullable = false)
+    private Integer seatNumber;
+
+    public SeatLocation(String column, Integer seatNumber) {
+        validate(column, seatNumber);
+        this.column = column;
+        this.seatNumber = seatNumber;
+    }
+
+    private void validate(String column, Integer seatNumber) {
+        if (column == null || column.isBlank()) {
+            throw new BadRequestException("column is required");
+        }
+
+        if (column.length() > 10) {
+            throw new BadRequestException("column max length is 10");
+        }
+
+        if (seatNumber == null || seatNumber <= 0) {
+            throw new BadRequestException("seatNumber must be positive");
+        }
+    }
+
+    public String label() {
+        return column + "-" + seatNumber;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof SeatLocation that)) return false;
+        return Objects.equals(column, that.column)
+                && Objects.equals(seatNumber, that.seatNumber);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(column, seatNumber);
+    }
+}

--- a/src/main/java/org/ticketing/seat/domain/repository/SeatGradeRepository.java
+++ b/src/main/java/org/ticketing/seat/domain/repository/SeatGradeRepository.java
@@ -1,0 +1,4 @@
+package org.ticketing.seat.domain.repository;
+
+public interface SeatGradeRepository {
+}

--- a/src/main/java/org/ticketing/seat/domain/repository/SeatRepository.java
+++ b/src/main/java/org/ticketing/seat/domain/repository/SeatRepository.java
@@ -1,0 +1,4 @@
+package org.ticketing.seat.domain.repository;
+
+public interface SeatRepository {
+}

--- a/src/main/java/org/ticketing/seat/domain/service/StadiumProvider.java
+++ b/src/main/java/org/ticketing/seat/domain/service/StadiumProvider.java
@@ -1,0 +1,7 @@
+package org.ticketing.seat.domain.service;
+
+import java.util.UUID;
+
+public interface StadiumProvider {
+    boolean existsById(UUID stadiumId);
+}

--- a/src/main/java/org/ticketing/seat/infrastructure/client/StadiumClient.java
+++ b/src/main/java/org/ticketing/seat/infrastructure/client/StadiumClient.java
@@ -1,0 +1,14 @@
+package org.ticketing.seat.infrastructure.client;
+
+import org.springframework.cloud.openfeign.FeignClient;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+
+import java.util.UUID;
+
+@FeignClient(name = "stadium-service")
+public interface StadiumClient {
+
+    @GetMapping("/internal/stadiums/{stadiumId}/exists")
+    boolean existsById(@PathVariable("stadiumId") UUID stadiumId);
+}

--- a/src/main/java/org/ticketing/seat/infrastructure/persistence/JpaSeatGradeRepository.java
+++ b/src/main/java/org/ticketing/seat/infrastructure/persistence/JpaSeatGradeRepository.java
@@ -1,0 +1,9 @@
+package org.ticketing.seat.infrastructure.persistence;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.ticketing.seat.domain.model.entity.SeatGrade;
+
+import java.util.UUID;
+
+public interface JpaSeatGradeRepository extends JpaRepository<SeatGrade, UUID> {
+}

--- a/src/main/java/org/ticketing/seat/infrastructure/persistence/JpaSeatRepository.java
+++ b/src/main/java/org/ticketing/seat/infrastructure/persistence/JpaSeatRepository.java
@@ -1,0 +1,9 @@
+package org.ticketing.seat.infrastructure.persistence;
+
+import org.springframework.data.repository.CrudRepository;
+import org.ticketing.seat.domain.model.entity.Seat;
+
+import java.util.UUID;
+
+public interface JpaSeatRepository extends CrudRepository<Seat, UUID> {
+}

--- a/src/main/java/org/ticketing/seat/infrastructure/persistence/SeatGradeRepositoryImpl.java
+++ b/src/main/java/org/ticketing/seat/infrastructure/persistence/SeatGradeRepositoryImpl.java
@@ -1,0 +1,12 @@
+package org.ticketing.seat.infrastructure.persistence;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+import org.ticketing.seat.domain.repository.SeatGradeRepository;
+
+@Repository
+@RequiredArgsConstructor
+public class SeatGradeRepositoryImpl implements SeatGradeRepository {
+
+    private final JpaSeatGradeRepository jpaSeatGradeRepository;
+}

--- a/src/main/java/org/ticketing/seat/infrastructure/persistence/SeatRepositoryImpl.java
+++ b/src/main/java/org/ticketing/seat/infrastructure/persistence/SeatRepositoryImpl.java
@@ -1,0 +1,13 @@
+package org.ticketing.seat.infrastructure.persistence;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+import org.ticketing.seat.domain.repository.SeatRepository;
+
+@Repository
+@RequiredArgsConstructor
+public class SeatRepositoryImpl implements SeatRepository {
+
+    private final JpaSeatRepository jpaSeatRepository;
+
+}

--- a/src/main/java/org/ticketing/seat/infrastructure/provider/StadiumProviderImpl.java
+++ b/src/main/java/org/ticketing/seat/infrastructure/provider/StadiumProviderImpl.java
@@ -1,0 +1,20 @@
+package org.ticketing.seat.infrastructure.provider;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import org.ticketing.seat.domain.service.StadiumProvider;
+import org.ticketing.seat.infrastructure.client.StadiumClient;
+
+import java.util.UUID;
+
+@Component
+@RequiredArgsConstructor
+public class StadiumProviderImpl implements StadiumProvider {
+
+    private final StadiumClient stadiumClient;
+
+    @Override
+    public boolean existsById(UUID stadiumId) {
+        return stadiumClient.existsById(stadiumId);
+    }
+}

--- a/src/main/java/org/ticketing/seat/presentation/controller/external/SeatController.java
+++ b/src/main/java/org/ticketing/seat/presentation/controller/external/SeatController.java
@@ -1,0 +1,125 @@
+package org.ticketing.seat.presentation.controller.external;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Pageable;
+import org.springframework.web.bind.annotation.*;
+import org.ticketing.seat.application.dto.command.DeleteSeatCommand;
+import org.ticketing.seat.application.dto.command.DeleteSeatGradeCommand;
+import org.ticketing.seat.application.service.SeatApplicationService;
+import org.ticketing.seat.presentation.dto.request.*;
+import org.ticketing.seat.presentation.dto.response.*;
+
+import java.util.UUID;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api")
+public class SeatController {
+
+    private final SeatApplicationService seatService;
+
+    /**
+     * 좌석 생성
+     */
+    @PostMapping("/seats")
+    public void createSeats(
+            @RequestBody CreateSeatsRequestDto request
+    ) {
+        seatService.createSeats(request.toCommand());
+    }
+
+    /**
+     * 좌석 자동 생성 (bulk)
+     */
+    @PostMapping("/seats/bulk")
+    public void bulkCreateSeats(
+            @RequestBody CreateSeatsBulkRequestDto request
+    ) {
+        seatService.bulkCreateSeats(request.toCommand());
+    }
+
+    /**
+     * 좌석 목록 조회
+     */
+    @GetMapping("/seats")
+    public GetSeatsResponseDto getSeats(
+            @ModelAttribute GetSeatsRequestDto request,
+            Pageable pageable
+    ) {
+        return GetSeatsResponseDto.from(seatService.getSeats(request.toQuery(pageable)));
+    }
+
+    /**
+     * 좌석 단건 조회
+     */
+    @GetMapping("/seats/{seatId}")
+    public SeatResponseDto getSeat(
+            @PathVariable UUID seatId
+    ) {
+        return SeatResponseDto.from(seatService.getSeat(seatId));
+    }
+
+    /**
+     * 좌석 등급 변경
+     */
+    @PatchMapping("/seats/{seatId}/grade")
+    public void updateSeatGrade(
+            @PathVariable UUID seatId,
+            @RequestBody UpdateSeatGradeRequestDto request
+    ) {
+        seatService.updateSeatGrade(request.toCommand(seatId));
+    }
+
+    /**
+     * 좌석 삭제
+     */
+    @DeleteMapping("/seats/{seatId}")
+    public void deleteSeat(
+            @PathVariable UUID seatId
+    ) {
+        seatService.deleteSeat(new DeleteSeatCommand(seatId, "temp"));
+    }
+
+    /**
+     * 좌석 등급 생성
+     */
+    @PostMapping("/seat-grades")
+    public void createSeatGrade(
+            @RequestBody CreateSeatGradeRequestDto request
+    ) {
+        seatService.createSeatGrade(request.toCommand());
+    }
+
+    /**
+     * 좌석 등급명 수정
+     */
+    @PatchMapping("/seat-grades/{seatGradeId}")
+    public void updateSeatGradeName(
+            @PathVariable UUID seatGradeId,
+            @RequestBody UpdateSeatGradeNameRequestDto request
+    ) {
+        seatService.updateSeatGradeName(request.toCommand(seatGradeId));
+    }
+
+    /**
+     * 좌석 등급 삭제
+     */
+    @DeleteMapping("/seat-grades/{seatGradeId}")
+    public void deleteSeatGrade(
+            @PathVariable UUID seatGradeId
+    ) {
+        seatService.deleteSeatGrade(new DeleteSeatGradeCommand(seatGradeId, "temp"));
+    }
+
+    /**
+     * 경기장 좌석 등급 목록 조회
+     */
+    @GetMapping("/seat-grades/{stadiumId}")
+    public GetSeatGradesResponseDto getSeatGrades(
+            @PathVariable UUID stadiumId
+    ) {
+        return GetSeatGradesResponseDto.from(
+                seatService.getSeatGrades(stadiumId)
+        );
+    }
+}

--- a/src/main/java/org/ticketing/seat/presentation/controller/external/SeatController.java
+++ b/src/main/java/org/ticketing/seat/presentation/controller/external/SeatController.java
@@ -13,7 +13,7 @@ import java.util.UUID;
 
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("/api")
+@RequestMapping("/api/seats")
 public class SeatController {
 
     private final SeatApplicationService seatService;
@@ -21,7 +21,7 @@ public class SeatController {
     /**
      * 좌석 생성
      */
-    @PostMapping("/seats")
+    @PostMapping
     public void createSeats(
             @RequestBody CreateSeatsRequestDto request
     ) {
@@ -31,7 +31,7 @@ public class SeatController {
     /**
      * 좌석 자동 생성 (bulk)
      */
-    @PostMapping("/seats/bulk")
+    @PostMapping("/bulk")
     public void bulkCreateSeats(
             @RequestBody CreateSeatsBulkRequestDto request
     ) {
@@ -41,7 +41,7 @@ public class SeatController {
     /**
      * 좌석 목록 조회
      */
-    @GetMapping("/seats")
+    @GetMapping
     public GetSeatsResponseDto getSeats(
             @ModelAttribute GetSeatsRequestDto request,
             Pageable pageable
@@ -52,7 +52,7 @@ public class SeatController {
     /**
      * 좌석 단건 조회
      */
-    @GetMapping("/seats/{seatId}")
+    @GetMapping("/{seatId}")
     public SeatResponseDto getSeat(
             @PathVariable UUID seatId
     ) {
@@ -62,7 +62,7 @@ public class SeatController {
     /**
      * 좌석 등급 변경
      */
-    @PatchMapping("/seats/{seatId}/grade")
+    @PatchMapping("/{seatId}/grade")
     public void updateSeatGrade(
             @PathVariable UUID seatId,
             @RequestBody UpdateSeatGradeRequestDto request
@@ -73,53 +73,10 @@ public class SeatController {
     /**
      * 좌석 삭제
      */
-    @DeleteMapping("/seats/{seatId}")
+    @DeleteMapping("/{seatId}")
     public void deleteSeat(
             @PathVariable UUID seatId
     ) {
         seatService.deleteSeat(new DeleteSeatCommand(seatId, "temp"));
-    }
-
-    /**
-     * 좌석 등급 생성
-     */
-    @PostMapping("/seat-grades")
-    public void createSeatGrade(
-            @RequestBody CreateSeatGradeRequestDto request
-    ) {
-        seatService.createSeatGrade(request.toCommand());
-    }
-
-    /**
-     * 좌석 등급명 수정
-     */
-    @PatchMapping("/seat-grades/{seatGradeId}")
-    public void updateSeatGradeName(
-            @PathVariable UUID seatGradeId,
-            @RequestBody UpdateSeatGradeNameRequestDto request
-    ) {
-        seatService.updateSeatGradeName(request.toCommand(seatGradeId));
-    }
-
-    /**
-     * 좌석 등급 삭제
-     */
-    @DeleteMapping("/seat-grades/{seatGradeId}")
-    public void deleteSeatGrade(
-            @PathVariable UUID seatGradeId
-    ) {
-        seatService.deleteSeatGrade(new DeleteSeatGradeCommand(seatGradeId, "temp"));
-    }
-
-    /**
-     * 경기장 좌석 등급 목록 조회
-     */
-    @GetMapping("/seat-grades/{stadiumId}")
-    public GetSeatGradesResponseDto getSeatGrades(
-            @PathVariable UUID stadiumId
-    ) {
-        return GetSeatGradesResponseDto.from(
-                seatService.getSeatGrades(stadiumId)
-        );
     }
 }

--- a/src/main/java/org/ticketing/seat/presentation/controller/external/SeatGradeController.java
+++ b/src/main/java/org/ticketing/seat/presentation/controller/external/SeatGradeController.java
@@ -1,0 +1,63 @@
+package org.ticketing.seat.presentation.controller.external;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.*;
+import org.ticketing.seat.application.dto.command.DeleteSeatGradeCommand;
+import org.ticketing.seat.application.service.SeatApplicationService;
+import org.ticketing.seat.application.service.SeatGradeApplicationService;
+import org.ticketing.seat.presentation.dto.request.CreateSeatGradeRequestDto;
+import org.ticketing.seat.presentation.dto.request.UpdateSeatGradeNameRequestDto;
+import org.ticketing.seat.presentation.dto.response.GetSeatGradesResponseDto;
+
+import java.util.UUID;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/seat-grades")
+public class SeatGradeController {
+
+    private final SeatGradeApplicationService seatGradeService;
+
+    /**
+     * 좌석 등급 생성
+     */
+    @PostMapping
+    public void createSeatGrade(
+            @RequestBody CreateSeatGradeRequestDto request
+    ) {
+        seatGradeService.createSeatGrade(request.toCommand());
+    }
+
+    /**
+     * 좌석 등급명 수정
+     */
+    @PatchMapping("/{seatGradeId}")
+    public void updateSeatGradeName(
+            @PathVariable UUID seatGradeId,
+            @RequestBody UpdateSeatGradeNameRequestDto request
+    ) {
+        seatGradeService.updateSeatGradeName(request.toCommand(seatGradeId));
+    }
+
+    /**
+     * 좌석 등급 삭제
+     */
+    @DeleteMapping("/{seatGradeId}")
+    public void deleteSeatGrade(
+            @PathVariable UUID seatGradeId
+    ) {
+        seatGradeService.deleteSeatGrade(new DeleteSeatGradeCommand(seatGradeId, "temp"));
+    }
+
+    /**
+     * 경기장 좌석 등급 목록 조회
+     */
+    @GetMapping("/{stadiumId}")
+    public GetSeatGradesResponseDto getSeatGrades(
+            @PathVariable UUID stadiumId
+    ) {
+        return GetSeatGradesResponseDto.from(
+                seatGradeService.getSeatGrades(stadiumId)
+        );
+    }
+}

--- a/src/main/java/org/ticketing/seat/presentation/controller/internal/SeatInternalController.java
+++ b/src/main/java/org/ticketing/seat/presentation/controller/internal/SeatInternalController.java
@@ -3,6 +3,7 @@ package org.ticketing.seat.presentation.controller.internal;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.*;
 import org.ticketing.seat.application.service.SeatApplicationService;
+import org.ticketing.seat.application.service.SeatGradeApplicationService;
 import org.ticketing.seat.presentation.dto.response.SeatGradeResponseDto;
 import org.ticketing.seat.presentation.dto.response.SeatResponseDto;
 
@@ -15,6 +16,7 @@ import java.util.UUID;
 public class SeatInternalController {
 
     private final SeatApplicationService seatService;
+    private final SeatGradeApplicationService seatGradeService;
 
     @GetMapping("/seats/{stadiumId}")
     public List<SeatResponseDto> getSeatsByStadium(
@@ -30,7 +32,7 @@ public class SeatInternalController {
     public List<SeatGradeResponseDto> getSeatGradesByStadium(
             @PathVariable UUID stadiumId
     ) {
-        return seatService.getSeatGrades(stadiumId)
+        return seatGradeService.getSeatGrades(stadiumId)
                 .seatGrades()
                 .stream()
                 .map(SeatGradeResponseDto::from)
@@ -39,6 +41,6 @@ public class SeatInternalController {
 
     @GetMapping("/seat-grades/{seatGradeId}/exists")
     public boolean existsSeatGrade(@PathVariable UUID seatGradeId) {
-        return seatService.existsSeatGrade(seatGradeId);
+        return seatGradeService.existsSeatGrade(seatGradeId);
     }
 }

--- a/src/main/java/org/ticketing/seat/presentation/controller/internal/SeatInternalController.java
+++ b/src/main/java/org/ticketing/seat/presentation/controller/internal/SeatInternalController.java
@@ -1,0 +1,44 @@
+package org.ticketing.seat.presentation.controller.internal;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.*;
+import org.ticketing.seat.application.service.SeatApplicationService;
+import org.ticketing.seat.presentation.dto.response.SeatGradeResponseDto;
+import org.ticketing.seat.presentation.dto.response.SeatResponseDto;
+
+import java.util.List;
+import java.util.UUID;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/internal")
+public class SeatInternalController {
+
+    private final SeatApplicationService seatService;
+
+    @GetMapping("/seats/{stadiumId}")
+    public List<SeatResponseDto> getSeatsByStadium(
+            @PathVariable UUID stadiumId
+    ) {
+        return seatService.getSeatsByStadium(stadiumId)
+                .stream()
+                .map(SeatResponseDto::from)
+                .toList();
+    }
+
+    @GetMapping("/seat-grades/{stadiumId}")
+    public List<SeatGradeResponseDto> getSeatGradesByStadium(
+            @PathVariable UUID stadiumId
+    ) {
+        return seatService.getSeatGrades(stadiumId)
+                .seatGrades()
+                .stream()
+                .map(SeatGradeResponseDto::from)
+                .toList();
+    }
+
+    @GetMapping("/seat-grades/{seatGradeId}/exists")
+    public boolean existsSeatGrade(@PathVariable UUID seatGradeId) {
+        return seatService.existsSeatGrade(seatGradeId);
+    }
+}

--- a/src/main/java/org/ticketing/seat/presentation/dto/request/CreateSeatGradeRequestDto.java
+++ b/src/main/java/org/ticketing/seat/presentation/dto/request/CreateSeatGradeRequestDto.java
@@ -1,0 +1,18 @@
+package org.ticketing.seat.presentation.dto.request;
+
+import org.ticketing.seat.application.dto.command.CreateSeatGradeCommand;
+
+import java.util.UUID;
+
+public record CreateSeatGradeRequestDto(
+        UUID stadiumId,
+        String gradeName
+) {
+
+    public CreateSeatGradeCommand toCommand() {
+        return new CreateSeatGradeCommand(
+                stadiumId,
+                gradeName
+        );
+    }
+}

--- a/src/main/java/org/ticketing/seat/presentation/dto/request/CreateSeatsBulkRequestDto.java
+++ b/src/main/java/org/ticketing/seat/presentation/dto/request/CreateSeatsBulkRequestDto.java
@@ -1,0 +1,25 @@
+package org.ticketing.seat.presentation.dto.request;
+
+import org.ticketing.seat.application.dto.command.CreateSeatsBulkCommand;
+
+import java.util.List;
+import java.util.UUID;
+
+public record CreateSeatsBulkRequestDto(
+        UUID stadiumId,
+        UUID seatGradeId,
+        List<String> columns,
+        Integer startNumber,
+        Integer endNumber
+) {
+
+    public CreateSeatsBulkCommand toCommand() {
+        return new CreateSeatsBulkCommand(
+                stadiumId,
+                seatGradeId,
+                columns,
+                startNumber,
+                endNumber
+        );
+    }
+}

--- a/src/main/java/org/ticketing/seat/presentation/dto/request/CreateSeatsRequestDto.java
+++ b/src/main/java/org/ticketing/seat/presentation/dto/request/CreateSeatsRequestDto.java
@@ -1,0 +1,31 @@
+package org.ticketing.seat.presentation.dto.request;
+
+import org.ticketing.seat.application.dto.command.CreateSeatsCommand;
+
+import java.util.List;
+import java.util.UUID;
+
+public record CreateSeatsRequestDto(
+        UUID stadiumId,
+        List<SeatCreateItem> seats
+) {
+
+    public CreateSeatsCommand toCommand() {
+        return new CreateSeatsCommand(
+                stadiumId,
+                seats.stream()
+                        .map(seat -> new CreateSeatsCommand.SeatItem(
+                                seat.column(),
+                                seat.seatNumber(),
+                                seat.seatGradeId()
+                        ))
+                        .toList()
+        );
+    }
+
+    public record SeatCreateItem(
+            String column,
+            Integer seatNumber,
+            UUID seatGradeId
+    ) {}
+}

--- a/src/main/java/org/ticketing/seat/presentation/dto/request/GetSeatsRequestDto.java
+++ b/src/main/java/org/ticketing/seat/presentation/dto/request/GetSeatsRequestDto.java
@@ -1,0 +1,22 @@
+package org.ticketing.seat.presentation.dto.request;
+
+import org.springframework.data.domain.Pageable;
+import org.ticketing.seat.application.dto.query.GetSeatsQuery;
+
+import java.util.UUID;
+
+public record GetSeatsRequestDto(
+        UUID stadiumId,
+        UUID seatGradeId,
+        String column
+) {
+
+    public GetSeatsQuery toQuery(Pageable pageable) {
+        return new GetSeatsQuery(
+                stadiumId,
+                seatGradeId,
+                column,
+                pageable
+        );
+    }
+}

--- a/src/main/java/org/ticketing/seat/presentation/dto/request/UpdateSeatGradeNameRequestDto.java
+++ b/src/main/java/org/ticketing/seat/presentation/dto/request/UpdateSeatGradeNameRequestDto.java
@@ -1,0 +1,4 @@
+package org.ticketing.seat.presentation.dto.request;
+
+public class UpdateSeatGradeNameRequestDto {
+}

--- a/src/main/java/org/ticketing/seat/presentation/dto/request/UpdateSeatGradeNameRequestDto.java
+++ b/src/main/java/org/ticketing/seat/presentation/dto/request/UpdateSeatGradeNameRequestDto.java
@@ -1,4 +1,17 @@
 package org.ticketing.seat.presentation.dto.request;
 
-public class UpdateSeatGradeNameRequestDto {
+import org.ticketing.seat.application.dto.command.UpdateSeatGradeNameCommand;
+
+import java.util.UUID;
+
+public record UpdateSeatGradeNameRequestDto(
+        String gradeName
+) {
+
+    public UpdateSeatGradeNameCommand toCommand(UUID seatGradeId) {
+        return new UpdateSeatGradeNameCommand(
+                seatGradeId,
+                gradeName
+        );
+    }
 }

--- a/src/main/java/org/ticketing/seat/presentation/dto/request/UpdateSeatGradeRequestDto.java
+++ b/src/main/java/org/ticketing/seat/presentation/dto/request/UpdateSeatGradeRequestDto.java
@@ -1,0 +1,17 @@
+package org.ticketing.seat.presentation.dto.request;
+
+import org.ticketing.seat.application.dto.command.UpdateSeatGradeCommand;
+
+import java.util.UUID;
+
+public record UpdateSeatGradeRequestDto(
+        UUID seatGradeId
+) {
+
+    public UpdateSeatGradeCommand toCommand(UUID seatId) {
+        return new UpdateSeatGradeCommand(
+                seatId,
+                seatGradeId
+        );
+    }
+}

--- a/src/main/java/org/ticketing/seat/presentation/dto/response/GetSeatGradesResponseDto.java
+++ b/src/main/java/org/ticketing/seat/presentation/dto/response/GetSeatGradesResponseDto.java
@@ -1,0 +1,18 @@
+package org.ticketing.seat.presentation.dto.response;
+
+import org.ticketing.seat.application.dto.result.GetSeatGradesResult;
+
+import java.util.List;
+
+public record GetSeatGradesResponseDto(
+        List<SeatGradeResponseDto> seatGrades
+) {
+
+    public static GetSeatGradesResponseDto from(GetSeatGradesResult result) {
+        return new GetSeatGradesResponseDto(
+                result.seatGrades().stream()
+                        .map(SeatGradeResponseDto::from)
+                        .toList()
+        );
+    }
+}

--- a/src/main/java/org/ticketing/seat/presentation/dto/response/GetSeatsResponseDto.java
+++ b/src/main/java/org/ticketing/seat/presentation/dto/response/GetSeatsResponseDto.java
@@ -1,0 +1,27 @@
+package org.ticketing.seat.presentation.dto.response;
+
+import org.ticketing.seat.application.dto.result.GetSeatsResult;
+import org.ticketing.seat.application.dto.result.SeatResult;
+
+import java.util.List;
+
+public record GetSeatsResponseDto(
+        List<SeatResponseDto> seats,
+        int page,
+        int size,
+        long totalElements,
+        int totalPages
+) {
+
+    public static GetSeatsResponseDto from(GetSeatsResult result) {
+        return new GetSeatsResponseDto(
+                result.seats().stream()
+                        .map(SeatResponseDto::from)
+                        .toList(),
+                result.page(),
+                result.size(),
+                result.totalElements(),
+                result.totalPages()
+        );
+    }
+}

--- a/src/main/java/org/ticketing/seat/presentation/dto/response/SeatGradeResponseDto.java
+++ b/src/main/java/org/ticketing/seat/presentation/dto/response/SeatGradeResponseDto.java
@@ -1,0 +1,18 @@
+package org.ticketing.seat.presentation.dto.response;
+
+import org.ticketing.seat.application.dto.result.SeatGradeResult;
+
+import java.util.UUID;
+
+public record SeatGradeResponseDto(
+        UUID seatGradeId,
+        String gradeName
+) {
+
+    public static SeatGradeResponseDto from(SeatGradeResult result) {
+        return new SeatGradeResponseDto(
+                result.seatGradeId(),
+                result.gradeName()
+        );
+    }
+}

--- a/src/main/java/org/ticketing/seat/presentation/dto/response/SeatResponseDto.java
+++ b/src/main/java/org/ticketing/seat/presentation/dto/response/SeatResponseDto.java
@@ -1,0 +1,26 @@
+package org.ticketing.seat.presentation.dto.response;
+
+import org.ticketing.seat.application.dto.result.SeatResult;
+
+import java.util.UUID;
+
+public record SeatResponseDto(
+        UUID seatId,
+        UUID stadiumId,
+        String column,
+        Integer seatNumber,
+        UUID seatGradeId,
+        String gradeName
+) {
+
+    public static SeatResponseDto from(SeatResult result) {
+        return new SeatResponseDto(
+                result.seatId(),
+                result.stadiumId(),
+                result.column(),
+                result.seatNumber(),
+                result.seatGradeId(),
+                result.gradeName()
+        );
+    }
+}

--- a/src/test/java/org/ticketing/seat/SeatServiceApplicationTests.java
+++ b/src/test/java/org/ticketing/seat/SeatServiceApplicationTests.java
@@ -1,4 +1,4 @@
-package com.ticketing.seat;
+package org.ticketing.seat;
 
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;


### PR DESCRIPTION
### 📎 관련 이슈
- close #1 

📌 작업 내용
- Seat-service domain 초기 설계
- 패키지 구조 설정
- entity 작성
- VO (location) 설계
- 도메인 예외 구조 정의
- Dto 작성
- service 스켈레톤 코드 작성

✨ 변경 사항

### 📝 리뷰 포인트 (선택)
- 집중해서 봐줬으면 하는 부분

### 🧠 기타 참고 사항
(참고 문서, 스크린샷 등)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Full seat and seat-grade management: create (single & bulk), read (including paginated/filterable lists), update grade/name, and soft-delete with audit.
  * New internal endpoints for stadium-scoped seat/grade retrieval and existence checks.
  * DTOs and response formats added for request/response mappings and pagination.

* **Chores**
  * Added automated code review/chat configuration (Korean, auto-reply).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->