### PR TITLE
fix: FeignClient 응답 타입 불일치로 인한 DecodeException 해결

### DIFF
--- a/src/main/java/org/ticketing/seat/domain/exception/StadiumNotFoundException.java
+++ b/src/main/java/org/ticketing/seat/domain/exception/StadiumNotFoundException.java
@@ -1,8 +1,10 @@
 package org.ticketing.seat.domain.exception;
 
+import org.ticketing.common.exception.NotFoundException;
+
 import java.util.UUID;
 
-public class StadiumNotFoundException extends RuntimeException {
+public class StadiumNotFoundException extends NotFoundException {
 
     public StadiumNotFoundException(UUID stadiumId) {
         super("Stadium not found: " + stadiumId);

--- a/src/main/java/org/ticketing/seat/infrastructure/client/StadiumClient.java
+++ b/src/main/java/org/ticketing/seat/infrastructure/client/StadiumClient.java
@@ -3,12 +3,13 @@ package org.ticketing.seat.infrastructure.client;
 import org.springframework.cloud.openfeign.FeignClient;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.ticketing.seat.infrastructure.client.dto.StadiumExistsResponse;
 
 import java.util.UUID;
 
-@FeignClient(name = "club-service")
+@FeignClient(name = "club-service", path = "/internal/stadiums")
 public interface StadiumClient {
 
-    @GetMapping("/internal/stadiums/{stadiumId}/exists")
-    boolean existsById(@PathVariable("stadiumId") UUID stadiumId);
+    @GetMapping("/{stadiumId}/exists")
+    StadiumExistsResponse existsById(@PathVariable("stadiumId") UUID stadiumId);
 }

--- a/src/main/java/org/ticketing/seat/infrastructure/client/dto/StadiumExistsResponse.java
+++ b/src/main/java/org/ticketing/seat/infrastructure/client/dto/StadiumExistsResponse.java
@@ -1,0 +1,9 @@
+package org.ticketing.seat.infrastructure.client.dto;
+
+public record StadiumExistsResponse (
+    boolean success,
+    String message,
+    Boolean data,
+    String traceId
+) {
+}

--- a/src/main/java/org/ticketing/seat/infrastructure/provider/StadiumProviderImpl.java
+++ b/src/main/java/org/ticketing/seat/infrastructure/provider/StadiumProviderImpl.java
@@ -18,6 +18,11 @@ public class StadiumProviderImpl implements StadiumProvider {
     public boolean existsById(UUID stadiumId) {
         StadiumExistsResponse response = stadiumClient.existsById(stadiumId);
 
-        return response != null && Boolean.FALSE.equals(response.data());
+        if(response == null || !response.success() || response.data() == null) {
+            throw new IllegalStateException("club-service 응답이 비정상입니다. traceId=" +
+                    (response != null ? response.traceId() : "null"));
+        }
+
+        return response.data();
     }
 }

--- a/src/main/java/org/ticketing/seat/infrastructure/provider/StadiumProviderImpl.java
+++ b/src/main/java/org/ticketing/seat/infrastructure/provider/StadiumProviderImpl.java
@@ -4,6 +4,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 import org.ticketing.seat.domain.service.StadiumProvider;
 import org.ticketing.seat.infrastructure.client.StadiumClient;
+import org.ticketing.seat.infrastructure.client.dto.StadiumExistsResponse;
 
 import java.util.UUID;
 
@@ -15,6 +16,8 @@ public class StadiumProviderImpl implements StadiumProvider {
 
     @Override
     public boolean existsById(UUID stadiumId) {
-        return stadiumClient.existsById(stadiumId);
+        StadiumExistsResponse response = stadiumClient.existsById(stadiumId);
+
+        return response != null && Boolean.FALSE.equals(response.data());
     }
 }


### PR DESCRIPTION
### 📎 관련 이슈
- close #5 

### 📌 작업 내용
- FeignClient(StadiumClient)의 반환 타입을 boolean → StadiumExistsResponse DTO로 변경
- Club Service의 공통 응답 포맷(success, message, data, traceId)에 맞도록 DTO 구조 정의
- StadiumProviderImpl에서 response.data() 값을 추출하여 boolean으로 반환하도록 수정

### ✨ 변경 사항
- 주요 변경 내용 정리

### 📝 리뷰 포인트 (선택)
- 집중해서 봐줬으면 하는 부분

### 🧠 기타 참고 사항
(참고 문서, 스크린샷 등)